### PR TITLE
Use $includes array for settings references

### DIFF
--- a/src/SleepingOwl/WithJoin/WithJoinEloquentBuilder.php
+++ b/src/SleepingOwl/WithJoin/WithJoinEloquentBuilder.php
@@ -219,12 +219,14 @@ class WithJoinEloquentBuilder extends Builder
 	*/
 	public function with($relations)
     {
-        parent::with($relations);
-
-        if ($relations) {
+		$includes = $this->getModel()->getIncludes();
+        if (is_array($includes)) {
+            $relations = array_unique(array_merge($relations, $includes));
             $this->references($relations);
         }
 
+        parent::with($relations);
+        
         return $this;
     }
 

--- a/src/SleepingOwl/WithJoin/WithJoinTrait.php
+++ b/src/SleepingOwl/WithJoin/WithJoinTrait.php
@@ -68,4 +68,9 @@ trait WithJoinTrait
 		return $query;
 	}
 
+    public function getIncludes()
+    {
+        return property_exists($this, 'includes') ? $this->includes : null;
+    }
+
 }


### PR DESCRIPTION
It now uses the includes array to set the references. I also added a test.
