### PR TITLE
Added example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Model::with('other')->references('other')->orderBy('other.title', 'asc')->get();
 Model::includes('first', 'second')->where('first.title', '=', 'my title')->get();
  # will be the same as Model::with('first', 'second')->references('first', 'second')->…
 
+Model extends Eloquent
+{
+	$includes = ['first', 'second'];
+}
+Model::where('first.title', '=', 'my title')->get();
+# result is same as Model::includes but definition is done within the model
+# if you use $with and $includes together it will be merged
+
 Model::with('foreign')->orderBy('field', 'asc')->get();
  # this will work with default behaviour (perform 2 sql-queries)
 ```


### PR DESCRIPTION
I added a piece of example code into the readme file.

Do you think it's better to change $includes to $include? Default Eloquent is also $with and no $withs.
