### PR TITLE
Fix relations not being passed on from trait

### DIFF
--- a/src/SleepingOwl/WithJoin/WithJoinEloquentBuilder.php
+++ b/src/SleepingOwl/WithJoin/WithJoinEloquentBuilder.php
@@ -224,6 +224,9 @@ class WithJoinEloquentBuilder extends Builder
 	 */
 	public function with($relations)
 	{
+		//if passing the relations as arguments, pass on to eloquents with
+		if (is_string($relations)) $relations = func_get_args();
+		
 		$includes = null;
 		try
 		{


### PR DESCRIPTION
Fixed the problem with relations not being passed on when using multiple arguments for the function instead of passing an array 
Fixed with @specialtactics